### PR TITLE
Fritzbox CardDAV compatibility

### DIFF
--- a/src/guru3-carddav/DAV/Guru3Item.cs
+++ b/src/guru3-carddav/DAV/Guru3Item.cs
@@ -49,6 +49,7 @@ namespace eventphone.guru3.carddav.DAV
             if (extension == null) return String.Empty;
             return "BEGIN:VCARD\n" +
                         "VERSION:4.0\n" +
+                        $"FN:{extension.Name.Escape()}\n" +
                         $"N:{extension.Name.Escape()}\n" +
                         $"TEL:{_number}\n" +
                         $"LANG:{extension.Language}\n" +


### PR DESCRIPTION
Since version 7.20, fritzboxes have the ability to sync CardDAV phonesbooks from the internet.

However, when adding the eventphone phonebooks, no contacts seem to appear in the phonebook on the fritzbox.
I was able to reproduce the same problem with my private SOGo address book, however some contacts were synced.
The only difference between those that show up and thos which don't was the existence of the FN attribute, in addition to just the N attribute.

This PR aims to add the FN attribute to the vcards to establish phonebook compatibility with fritzboxes.